### PR TITLE
Fix /terminal hosting

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,10 +12,6 @@ http {
         server vulcan-web:3030;
     }
 
-    upstream terminal {
-        server terminal:8080;
-    }
-
     upstream landing {
         server landing:4000;
     }
@@ -69,7 +65,7 @@ http {
         }
 
         location /terminal {
-            proxy_pass http://terminal/;
+            return 301 http://localhost:8080/;
         }
 
     }


### PR DESCRIPTION
This fixes #1 by redirecting all requests for `localhost/terminal` to `localhost:8080`. This isn't a great fix, but it will work for now. I'll try to figure out a proper fix with the terminal's server at some point.